### PR TITLE
Publish CNAME, set Vite base to root, and update deploy action for imboni.cn

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,3 +36,4 @@ jobs:
         with:
           folder: dist
           branch: gh-pages
+          cname: imboni.cn

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+imboni.cn

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,5 @@ import vue from '@vitejs/plugin-vue'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [vue()],
-  base: '/blog/',
+  base: '/',
 })


### PR DESCRIPTION
### Motivation
- Fix 404 by ensuring the site is served at the custom root domain `imboni.cn` rather than a subpath.
- Ensure GitHub Pages receives the `CNAME` so Pages recognizes the custom domain and enables HTTPS.
- Serve built assets from the root path so resource URLs resolve correctly when the site is hosted at the domain.

### Description
- Add `public/CNAME` containing `imboni.cn` so the CNAME is included in the build output.
- Update `.github/workflows/deploy.yml` to pass `cname: imboni.cn` to the deploy action so the `gh-pages` branch gets the CNAME on deploy.
- Change `vite.config.ts` `base` from `/blog/` to `/` so assets are referenced from the root path.
- Revert the README change that previously documented the custom-domain note so the README remains unchanged regarding the domain.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ad0c02d28832990ed962bd1fa87b3)